### PR TITLE
Adds logging to papertrail

### DIFF
--- a/PlatformIO/lib/RdNetLog/NetLog.h
+++ b/PlatformIO/lib/RdNetLog/NetLog.h
@@ -6,6 +6,7 @@
 
 #include <ArduinoLog.h>
 #include <WiFiClient.h>
+#include <WiFiUdp.h>
 #include "MQTTManager.h"
 #include "CommandSerial.h"
 #include "RingBufferPosn.h"
@@ -40,6 +41,9 @@ private:
     int _serialPort;
     int _logToCommandSerial;
     CommandSerial& _commandSerial;
+    bool _logToPapertrail;
+    String _papertrailHost;
+    int _papertrailPort;
     
     // Logging control
     int _loggingThreshold;
@@ -51,6 +55,9 @@ private:
     // TCP client
     WiFiClient _wifiClient;
     const int MAX_RX_BUFFER_SIZE = 100;
+
+    // UDP
+    WiFiUDP Udp;
 
     // System name
     String _systemName;
@@ -93,6 +100,7 @@ public:
     void setSerial(bool onOffFlag, const char* serialPortStr);
     void setCmdSerial(bool onOffFlag);
     void setHTTP(bool httpFlag, const char* ipAddr, const char* portStr, const char* httpLogUrl);
+    void setPapertrail(bool papertrailFlag, const char* hostStr, const char* portStr);
     void setup(ConfigBase *pConfig, const char* systemName);
     String formConfigStr();
     void pause();

--- a/PlatformIO/lib/RdRestAPISystem/RestAPISystem.cpp
+++ b/PlatformIO/lib/RdRestAPISystem/RestAPISystem.cpp
@@ -41,6 +41,9 @@ void RestAPISystem::setup(RestAPIEndpoints &endpoints)
     endpoints.addEndpoint("loghttp", RestAPIEndpointDef::ENDPOINT_CALLBACK, RestAPIEndpointDef::ENDPOINT_GET, 
                     std::bind(&RestAPISystem::apiNetLogHTTP, this, std::placeholders::_1, std::placeholders::_2), 
                     "Set log to HTTP /enable/host/port/url");
+    endpoints.addEndpoint("logpt", RestAPIEndpointDef::ENDPOINT_CALLBACK, RestAPIEndpointDef::ENDPOINT_GET, 
+                    std::bind(&RestAPISystem::apiNetLogPT, this, std::placeholders::_1, std::placeholders::_2), 
+                    "Set log to Papertail /enable/host/port");
     endpoints.addEndpoint("logserial", RestAPIEndpointDef::ENDPOINT_CALLBACK, RestAPIEndpointDef::ENDPOINT_GET, 
                     std::bind(&RestAPISystem::apiNetLogSerial, this, std::placeholders::_1, std::placeholders::_2), 
                     "Set log to serial /enable/port");
@@ -301,6 +304,18 @@ void RestAPISystem::apiNetLogHTTP(String &reqStr, String &respStr)
     Log.trace("%sNetLogHTTP %s, ipHost %s, port %s, url %s\n", MODULE_PREFIX, 
                         onOffFlag.c_str(), ipAddrOrHostname.c_str(), httpPortStr.c_str(), urlStr.c_str());
     _netLog.setHTTP(onOffFlag != "0", ipAddrOrHostname.c_str(), httpPortStr.c_str(), urlStr.c_str());
+    Utils::setJsonBoolResult(respStr, true);
+}
+
+void RestAPISystem::apiNetLogPT(String &reqStr, String &respStr)
+{
+    // Set PaperTrail as a destination for logging
+    String onOffFlag = RestAPIEndpoints::getNthArgStr(reqStr.c_str(), 1);
+    String hostName = RestAPIEndpoints::getNthArgStr(reqStr.c_str(), 2);
+    String portStr = RestAPIEndpoints::getNthArgStr(reqStr.c_str(), 3);
+    Log.trace("%sNetLogPT %s, host %s, port %s\n", MODULE_PREFIX, 
+                        onOffFlag.c_str(), hostName.c_str(), portStr.c_str());
+    _netLog.setPapertrail(onOffFlag != "0", hostName.c_str(), portStr.c_str());
     Utils::setJsonBoolResult(respStr, true);
 }
 

--- a/PlatformIO/lib/RdRestAPISystem/RestAPISystem.h
+++ b/PlatformIO/lib/RdRestAPISystem/RestAPISystem.h
@@ -80,6 +80,7 @@ public:
     void apiNetLogSerial(String &reqStr, String &respStr);
     void apiNetLogCmdSerial(String &reqStr, String &respStr);
     void apiNetLogHTTP(String &reqStr, String &respStr);
+    void apiNetLogPT(String &reqStr, String &respStr);
 
     // Command scheduler
     void apiCmdSchedGetConfig(String &reqStr, String &respStr);

--- a/PlatformIO/src/main.cpp
+++ b/PlatformIO/src/main.cpp
@@ -11,7 +11,7 @@
 //                                          - (e.g. /devicename/in becomes ~devicename~in)
 //   Check updates:  /checkupdate           - check for updates on the update server
 //   Reset:          /reset                 - reset device
-//   Log level:      /loglevel/lll          - Logging level (for MQTT and HTTP)
+//   Log level:      /loglevel/lll          - Logging level (for MQTT, HTTP and Papertrail)
 //                                          - lll one of v (verbose), t (trace), n (notice), w (warning), e (error), f (fatal)
 //   Log to MQTT:    /logmqtt/en/topic      - Control logging to MQTT
 //                                          - en = 0 or 1 for off/on, topic is the topic logging messages are sent to
@@ -19,6 +19,10 @@
 //                                          - en = 0 or 1 for off/on
 //                                          - ip is the IP address of the computer to log to (or hostname) and po is the port
 //                                          - ur is the HTTP url logging messages are POSTed to
+//   Log to Papertail:    /logpt/en/ho/po   - Control logging to Papertrail
+//                                          - en = 0 or 1 for off/on
+//                                          - ho is the papertrail host
+//                                          - po is the papertrail port
 //   Log to serial:  /logserial/en/port     - Control logging to serial
 //                                          - en = 0 or 1 for off/on
 //                                          - port is the port number 0 = standard USB port


### PR DESCRIPTION
Adds a logging output to Papertrail.

Sign up for a free account at papertrail.com and then create a new system. Papertail should tell you the host and the port number to use.

Run the following serial command:

/logpt/1/HOST/PORT

