### PR TITLE
Indicate Led config change from sleep command

### DIFF
--- a/PlatformIO/lib/MgLedStrip/LedStrip.cpp
+++ b/PlatformIO/lib/MgLedStrip/LedStrip.cpp
@@ -207,5 +207,10 @@ uint16_t LedStrip::getAverageSensorReading() {
 // Set sleep mode
 void LedStrip::setSleepMode(int sleep)
 {
+    // If coming out of sleep restore ledValue from Nvm
+    if (_isSleeping == true && sleep == false) {
+        setup(_pHwConfig, _name.c_str());
+    }
     _isSleeping = sleep;
+    ledConfigChanged = true;
 }


### PR DESCRIPTION
Discovered bug when sleep command is executed.  Led strip never updates without the changes in this PR.